### PR TITLE
[BUGFIX] Enabled /quiet mode.

### DIFF
--- a/params_info/params.h
+++ b/params_info/params.h
@@ -359,6 +359,7 @@ public:
 
         copyVal<BoolParam>(PARAM_LOOP, ps.loop_scanning);
         copyVal<BoolParam>(PARAM_LOG, ps.log);
+        copyVal<BoolParam>(PARAM_QUIET, ps.quiet);
         copyVal<IntParam>(PARAM_PTIMES, ps.ptimes);
         copyVal<BoolParam>(PARAM_JSON, ps.json_output);
 


### PR DESCRIPTION
Running 
> hollows_hunter64.exe /quiet

on Win10 x64 ignores the 'quiet' flag. This is true for both the latest release, and the current master branch.
The pull request seems to fix the issue.